### PR TITLE
Import built library for node example

### DIFF
--- a/example/node-example.js
+++ b/example/node-example.js
@@ -15,7 +15,7 @@ for(var k in obj){
 }
 sum
 `
-require('../dist/index')
+require('../duktapeEval')
 	.getInstance()
 	.then(mod => {
 		console.log('eval: ', eval(testString))


### PR DESCRIPTION
Just a quick fix for node-example to require the built library.